### PR TITLE
[COTLMP] Connect to the server immediately as a host after creating it

### DIFF
--- a/COTLMP/Ui/PauseMenu.cs
+++ b/COTLMP/Ui/PauseMenu.cs
@@ -174,9 +174,11 @@ namespace COTLMP.Ui
                     return false;
                 }
 
+                /* Run the main Server thread and let the host connect to it immediately */
                 __instance.Push<UIMenuConfirmationWindow>(MonoSingleton<UIManager>.Instance.ConfirmationWindowTemplate).Configure("Started server!", $"Port: {Server.Port}\nServer Name: {Server.serverName}\nGamemode: {TranslateGameModeToString(Server.gameMode)}", true);
                 Server.ServerStopped += ServerStopped;
-                _ = Server.Run();
+                _ = System.Threading.Tasks.Task.Run(Server.Run);
+                _ = COTLMP.Network.Network.Connect(new IPEndPoint(IPAddress.Parse("127.0.0.1"), Server.Port), tokenSource.Token);
             }
             return false;
         }

--- a/COTLMPServer/Server.cs
+++ b/COTLMPServer/Server.cs
@@ -31,7 +31,6 @@ namespace COTLMPServer
     /// </summary>
     public sealed class Server : IDisposable
     {
-        public readonly IPAddress Ip;
         public readonly int Port;
         public readonly string serverName;
         public readonly GameMode gameMode;
@@ -64,7 +63,6 @@ namespace COTLMPServer
             players = new ConcurrentDictionary<IPEndPoint, Player>();
 
             Port = (client.Client.LocalEndPoint as IPEndPoint)?.Port ?? 0;
-            Ip = (client.Client.LocalEndPoint as IPEndPoint)?.Address;
 
             gameVersion = ver;
             serverName = SrvName;
@@ -221,7 +219,7 @@ namespace COTLMPServer
 
             var args = new ServerStoppedArgs(ServerStopReason.NormalShutdown, "");
             CancellationTokenRegistration registration = token.Register(client.Dispose);
-            logger?.LogInfo("Started server at port " + Port + " with name " + serverName + $" (IP: {Ip} -- GameMode: {TranslateGameModeToString(gameMode)})!");
+            logger?.LogInfo("Started server at port " + Port + " with name " + serverName + $" ( GameMode: {TranslateGameModeToString(gameMode)})!");
 
             try
             {


### PR DESCRIPTION
The host must immediately join the server as soon as it creates the server through LAN. Also remove the `Ip` field from Server class because it's of no use.