### PR TITLE
[COTLMP:UI] Cache the Say chat related coroutines and stop them on shutdown

### DIFF
--- a/COTLMP/Ui/SayChat.cs
+++ b/COTLMP/Ui/SayChat.cs
@@ -31,6 +31,8 @@ namespace COTLMP.Ui
         private static Image SayBox;
         private static Component SayComponent;
         private static Player PlayerInstance;
+        private static Coroutine DisplayWorker;
+        private static Coroutine BroadcastWorker;
 
         /// <summary>
         /// Called by the Update() method of the core saychat box mechanism whenever a
@@ -127,7 +129,7 @@ namespace COTLMP.Ui
 
                 /* Acknowledge ourselves the saychat box has been spawned and setup the saychat worker */
                 BoxSpawned = true;
-                Plugin.MonoInstance.StartCoroutine(SayChatDisplayWorker());
+                DisplayWorker = Plugin.MonoInstance.StartCoroutine(SayChatDisplayWorker());
                 return;
             }
 
@@ -142,7 +144,7 @@ namespace COTLMP.Ui
                     if (Input.GetKeyDown(KeyCode.Return))
                     {
                         CapturedMessage = SayInput.text;
-                        Plugin.MonoInstance.StartCoroutine(BroadcastSayMessageWorker(CapturedMessage));
+                        BroadcastWorker = Plugin.MonoInstance.StartCoroutine(BroadcastSayMessageWorker(CapturedMessage));
                         return;
                     }
 
@@ -158,8 +160,8 @@ namespace COTLMP.Ui
         public static void Shutdown()
         {
             /* Cease any coroutine execution if any */
-            Plugin.MonoInstance.StopCoroutine(SayChatDisplayWorker());
-            Plugin.MonoInstance.StopCoroutine(BroadcastSayMessageWorker(null));
+            Plugin.MonoInstance.StopCoroutine(DisplayWorker);
+            Plugin.MonoInstance.StopCoroutine(BroadcastWorker);
 
             /* Close our attached component */
             Object.Destroy(SayComponent);


### PR DESCRIPTION
Giving the names of the coroutines to StopCoroutine directly doesn't make actually stopping the coroutines in the first place. Fix that by caching them on startup and use the cached coroutines on StopCoroutine to stop them properly.

Fixers #31. 
